### PR TITLE
Removed a deprecated method to be more compatible with Django 1.4

### DIFF
--- a/settings.py.default
+++ b/settings.py.default
@@ -58,7 +58,7 @@ SITE_ID = 1
 USE_I18N = True
 SECRET_KEY = 'REPLACEMENOW'
 # don't forget comma here. just love the python tuple!
-TEMPLATE_LOADERS = ('django.template.loaders.filesystem.load_template_source',)
+TEMPLATE_LOADERS = ('django.template.loaders.filesystem.Loader',)
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
I've just removed one [deprecated method](https://docs.djangoproject.com/en/dev/internals/deprecation/) from `settings.py.default`. (related to chb/indivo_server#13)
